### PR TITLE
New

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,7 @@
-module.exports = {
+const eslint = require('@eslint/js');
+const tseslint = require('typescript-eslint');
+
+module.exports = tseslint.config({
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
@@ -22,4 +25,4 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
   },
-};
+});

--- a/src/controllers/products.controller.ts
+++ b/src/controllers/products.controller.ts
@@ -31,9 +31,19 @@ export class ProductsController {
     return this.productsService.findById(id);
   }
 
+  @Get(':id/related')
+  getRelatedProducts(@Param('id', ParseIntPipe) id: number) {
+    return this.productsService.getRelatedProducts(id);
+  }
+
   @Get('slug/:slug')
   getProductBySlug(@Param('slug') slug: string) {
     return this.productsService.findBySlug(slug);
+  }
+
+  @Get('slug/:slug/related')
+  getRelatedProductsBySlug(@Param('slug') slug: string) {
+    return this.productsService.getRelatedProductsBySlug(slug);
   }
 
   @Post()

--- a/src/services/products.service.ts
+++ b/src/services/products.service.ts
@@ -7,6 +7,7 @@ import {
   FindManyOptions,
   Like,
   And,
+  Not,
 } from 'typeorm';
 
 import { Product } from '@db/entities/product.entity';
@@ -95,11 +96,28 @@ export class ProductsService {
     });
   }
 
+  async getRelatedProducts(id: number) {
+    const product = await this.findById(id);
+
+    return this.productsRepo.find({
+      relations: ['category'],
+      where: {
+        category: { id: product.category.id },
+        id: Not(id),
+      },
+    });
+  }
+
   findBySlug(slug: string) {
     return this.productsRepo.findOneOrFail({
       relations: ['category'],
       where: { slug },
     });
+  }
+
+  async getRelatedProductsBySlug(slug: string) {
+    const product = await this.findBySlug(slug);
+    return this.getRelatedProducts(product.id);
   }
 
   async update(id: Product['id'], changes: UpdateProductDto) {


### PR DESCRIPTION
This pull request includes several changes to improve the ESLint configuration and add functionality to the `ProductsController` and `ProductsService` classes. The most important changes include renaming and updating the ESLint configuration file, adding new endpoints to the `ProductsController`, and implementing methods to fetch related products in the `ProductsService`.

### ESLint Configuration Update:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L1-R4): Renamed from `.eslintrc.js` and updated to use `@eslint/js` and `typescript-eslint` for configuration. [[1]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L1-R4) [[2]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L25-R28)

### ProductsController Enhancements:

* [`src/controllers/products.controller.ts`](diffhunk://#diff-e53ebbbf170c9303e8f5d3ba968ea2b14279a055a0cbc10f89945452c6add31bR34-R48): Added new endpoints `getRelatedProducts` and `getRelatedProductsBySlug` to fetch related products by ID and slug, respectively.

### ProductsService Enhancements:

* [`src/services/products.service.ts`](diffhunk://#diff-f8cbb67100ba51a80c507f343c775c0e4b3cefbade3f05a6af0cd7a899fe880dR10): Added `Not` import from `typeorm` to support exclusion of the current product in related products query.
* [`src/services/products.service.ts`](diffhunk://#diff-f8cbb67100ba51a80c507f343c775c0e4b3cefbade3f05a6af0cd7a899fe880dR99-R122): Implemented `getRelatedProducts` and `getRelatedProductsBySlug` methods to fetch related products based on product ID and slug.